### PR TITLE
handle mms when no cellular data or any download issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,15 @@ requirements that satisfy an Ubuntu Phone (aka Ubuntu Touch).
 Addtional information:
 
 * [mmsd documentaion](https://kernel.googlesource.com/pub/scm/network/ofono/mmsd/+/master/doc/)
+
+
+Crossbuilder:
+
+crossbuilder inst-foreign dh-golang \
+    golang-1.6-doc \
+    golang-1.6 \
+    golang-go-dbus-dev \
+    golang-go-flags-dev \
+    golang-go-xdg-dev \
+    golang-gocheck-dev\
+    golang-udm-dev

--- a/cmd/nuntium/mediator.go
+++ b/cmd/nuntium/mediator.go
@@ -154,7 +154,6 @@ func (mediator *Mediator) getMRetrieveConf(mNotificationInd *mms.MNotificationIn
 
 	var proxy ofono.ProxyInfo
 	var mmsContext ofono.OfonoContext
-
 	if mNotificationInd.IsLocal() {
 		log.Print("This is a local test, skipping context activation and proxy settings")
 	} else {
@@ -163,6 +162,7 @@ func (mediator *Mediator) getMRetrieveConf(mNotificationInd *mms.MNotificationIn
 		mmsContext, err = mediator.modem.ActivateMMSContext(preferredContext)
 		if err != nil {
 			log.Print("Cannot activate ofono context: ", err)
+			mediator.telepathyService.IncomingMessageFailAdded(mNotificationInd.UUID, mNotificationInd.From)
 			return
 		}
 		defer func() {
@@ -177,6 +177,7 @@ func (mediator *Mediator) getMRetrieveConf(mNotificationInd *mms.MNotificationIn
 		proxy, err = mmsContext.GetProxy()
 		if err != nil {
 			log.Print("Error retrieving proxy: ", err)
+			mediator.telepathyService.IncomingMessageFailAdded(mNotificationInd.UUID, mNotificationInd.From)
 			return
 		}
 	}
@@ -184,6 +185,7 @@ func (mediator *Mediator) getMRetrieveConf(mNotificationInd *mms.MNotificationIn
 	if filePath, err := mNotificationInd.DownloadContent(proxy.Host, int32(proxy.Port)); err != nil {
 		//TODO telepathy service signal the download error
 		log.Print("Download issues: ", err)
+		mediator.telepathyService.IncomingMessageFailAdded(mNotificationInd.UUID, mNotificationInd.From)
 		return
 	} else {
 		if err := storage.UpdateDownloaded(mNotificationInd.UUID, filePath); err != nil {


### PR DESCRIPTION
This is part of the "quick" work-around as stated here https://forums.ubports.com/topic/5100/the-mms-lost-story
This catch any errors while retrieving the MMS and propagate to other services as an empty MMS.
Note that if related PRs are not shipped with this one, the user will be notified with vibration or sound but nothing will be displayed in notification or in messaging-app
Related PR:
 -  https://github.com/ubports/telephony-service/pull/13
 -  https://github.com/ubports/messaging-app/pull/248
Related issue: https://github.com/ubports/ubuntu-touch/issues/1408, https://github.com/ubports/ubuntu-touch/issues/239
