### PR TITLE
Fixes ofono test fail

### DIFF
--- a/ofono/manager.go
+++ b/ofono/manager.go
@@ -49,7 +49,7 @@ func (mm *ModemManager) Init() error {
 	//Use a different connection for the modem signals to avoid go-dbus blocking issues
 	conn, err := dbus.Connect(dbus.SystemBus)
 	if err != nil {
-		return err;
+		return err
 	}
 
 	modemAddedSignal, err := connectToSignal(conn, "/", OFONO_MANAGER_INTERFACE, "ModemAdded")
@@ -97,7 +97,7 @@ func (mm *ModemManager) watchModems(modemAdded, modemRemoved *dbus.SignalWatch) 
 
 func (mm *ModemManager) addModem(objectPath dbus.ObjectPath) {
 	if modem, ok := mm.modems[objectPath]; ok {
-		log.Print("Need to delete stale modem instance %s", modem.Modem)
+		log.Printf("Need to delete stale modem instance %s", modem.Modem)
 		modem.Delete()
 		delete(mm.modems, objectPath)
 	}

--- a/ofono/push.go
+++ b/ofono/push.go
@@ -102,7 +102,7 @@ func (dec *PushPDUDecoder) decodeHeaders(pdu *PushPDU, hdrLengthRemain int) erro
 			err = fmt.Errorf("Unhandled header data %#x @%d", dec.Data[dec.Offset], dec.Offset)
 		}
 		if err != nil {
-			return fmt.Errorf("error while decoding %#x @%d: ", param, dec.Offset, err)
+			return fmt.Errorf("error while decoding %#x @%d: %v", param, dec.Offset, err)
 		} else if pdu.ApplicationId != 0 {
 			return nil
 		}

--- a/ofono/pushagent.go
+++ b/ofono/pushagent.go
@@ -83,7 +83,7 @@ func (agent *PushAgent) Unregister() error {
 	agent.m.Lock()
 	defer agent.m.Unlock()
 	if !agent.Registered {
-		log.Print("Agent no registered for %s", agent.modem)
+		log.Printf("Agent no registered for %s", agent.modem)
 		return nil
 	}
 	log.Print("Unregistering agent on ", agent.modem)


### PR DESCRIPTION
When running ```./scripts/testcoverage.sh``` there are fails for ```go1.14```:
```bash
$ ./scripts/testcoverage.sh 
?   	github.com/jezek/nuntium/storage	[no test files]
# github.com/jezek/nuntium/ofono
ofono/manager.go:100: Print call has possible formatting directive %s
ofono/push.go:105: Errorf call needs 2 args but has 3 args
ofono/pushagent.go:86: Print call has possible formatting directive %s
FAIL	github.com/jezek/nuntium/ofono [build failed]
FAIL
?   	github.com/jezek/nuntium/telepathy	[no test files]
?   	github.com/jezek/nuntium/test	[no test files]
?   	github.com/jezek/nuntium/cmd/nuntium-inject-push	[no test files]
?   	github.com/jezek/nuntium/cmd/nuntium-decode-cli	[no test files]
?   	github.com/jezek/nuntium/cmd/nuntium	[no test files]
ok  	github.com/jezek/nuntium/mms	0.008s	coverage: 45.3% of statements
```

This PR fixes the test:
```bash
$ ./scripts/testcoverage.sh                             
?   	github.com/jezek/nuntium/storage	[no test files]
ok  	github.com/jezek/nuntium/ofono	0.008s	coverage: 22.3% of statements
?   	github.com/jezek/nuntium/telepathy	[no test files]
?   	github.com/jezek/nuntium/test	[no test files]
?   	github.com/jezek/nuntium/cmd/nuntium-inject-push	[no test files]
?   	github.com/jezek/nuntium/cmd/nuntium-decode-cli	[no test files]
?   	github.com/jezek/nuntium/cmd/nuntium	[no test files]
ok  	github.com/jezek/nuntium/mms	0.009s	coverage: 45.3% of statements
```

Note: It''s just logging typos fixing, this PR doesn't introduce any new logic or logic changes.