### PR TITLE
Change imports (and other) from ubuntu-phonedations to ubports

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,11 @@ requirements that satisfy an Ubuntu Phone (aka Ubuntu Touch).
 Addtional information:
 
 * [mmsd documentaion](https://kernel.googlesource.com/pub/scm/network/ofono/mmsd/+/master/doc/)
-
+* This project is a continuation of [the ubuntu-phonedations nuntium project](https://github.com/ubuntu-phonedations/nuntium/). 
 
 Crossbuilder:
 
+```bash
 crossbuilder inst-foreign dh-golang \
     golang-1.6-doc \
     golang-1.6 \
@@ -27,3 +28,4 @@ crossbuilder inst-foreign dh-golang \
     golang-go-xdg-dev \
     golang-gocheck-dev\
     golang-udm-dev
+```

--- a/cmd/nuntium-decode-cli/decode.go
+++ b/cmd/nuntium-decode-cli/decode.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/ubuntu-phonedations/nuntium/mms"
+	"github.com/ubports/nuntium/mms"
 )
 
 func main() {

--- a/cmd/nuntium/main.go
+++ b/cmd/nuntium/main.go
@@ -26,8 +26,8 @@ import (
 	"os"
 	"syscall"
 
-	"github.com/ubuntu-phonedations/nuntium/ofono"
-	"github.com/ubuntu-phonedations/nuntium/telepathy"
+	"github.com/ubports/nuntium/ofono"
+	"github.com/ubports/nuntium/telepathy"
 	"launchpad.net/go-dbus/v1"
 )
 

--- a/cmd/nuntium/mediator.go
+++ b/cmd/nuntium/mediator.go
@@ -29,11 +29,10 @@ import (
 	"os/user"
 	"sync"
 
-	"github.com/ubuntu-phonedations/nuntium/mms"
-	"github.com/ubuntu-phonedations/nuntium/ofono"
-	"github.com/ubuntu-phonedations/nuntium/storage"
-	"github.com/ubuntu-phonedations/nuntium/telepathy"
-
+	"github.com/ubports/nuntium/mms"
+	"github.com/ubports/nuntium/ofono"
+	"github.com/ubports/nuntium/storage"
+	"github.com/ubports/nuntium/telepathy"
 	"launchpad.net/go-dbus/v1"
 )
 

--- a/debian/golang-nuntium-mms-dev.install
+++ b/debian/golang-nuntium-mms-dev.install
@@ -1,1 +1,1 @@
-usr/share/gocode/src/github.com/ubuntu-phonedations/nuntium/mms
+usr/share/gocode/src/github.com/ubports/nuntium/mms

--- a/debian/golang-nuntium-ofono-dev.install
+++ b/debian/golang-nuntium-ofono-dev.install
@@ -1,1 +1,1 @@
-usr/share/gocode/src/github.com/ubuntu-phonedations/nuntium/ofono
+usr/share/gocode/src/github.com/ubports/nuntium/ofono

--- a/debian/golang-nuntium-telepathy-dev.install
+++ b/debian/golang-nuntium-telepathy-dev.install
@@ -1,1 +1,1 @@
-usr/share/gocode/src/github.com/ubuntu-phonedations/nuntium/telepathy
+usr/share/gocode/src/github.com/ubports/nuntium/telepathy

--- a/debian/rules
+++ b/debian/rules
@@ -2,7 +2,7 @@
 # -*- makefile -*-
 
 export DH_OPTIONS
-export DH_GOPKG := github.com/ubuntu-phonedations/nuntium
+export DH_GOPKG := github.com/ubports/nuntium
 export DH_GOLANG_INSTALL_ALL := 1
 
 DEB_HOST_ARCH := $(shell dpkg-architecture -qDEB_HOST_ARCH)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -14,9 +14,9 @@ artifacts into a specific path.
 
 Install it by running:
 
-    go get github.com/ubuntu-phonedations/nuntium/cmd/nuntium-decode-cli
+    go get github.com/ubports/nuntium/cmd/nuntium-decode-cli
 
-Refer to the tool's [documentation](http://godoc.org/github.com/ubuntu-phonedations/nuntium/cmd/nuntium-decode-cli)
+Refer to the tool's [documentation](https://pkg.go.dev/github.com/ubports/nuntium/cmd/nuntium-decode-cli)
 for more information.
 
 
@@ -29,10 +29,10 @@ when trying to activate a context.
 
 Install it by running:
 
-    go get github.com/ubuntu-phonedations/nuntium/cmd/nuntium-preferred-context
+    go get github.com/ubports/nuntium/cmd/nuntium-preferred-context
 
 Refer to the tool's
-[documentation](http://godoc.org/github.com/ubuntu-phonedations/nuntium/cmd/nuntium-preferred-context)
+[documentation](https://pkg.go.dev/github.com/ubports/nuntium/cmd/nuntium-preferred-context)
 for more information.
 
 
@@ -77,7 +77,7 @@ simulate a black box workflow as described in
 
 Install it by running:
 
-    go get github.com/ubuntu-phonedations/nuntium/cmd/nuntium-inject-push
+    go get github.com/ubports/nuntium/cmd/nuntium-inject-push
 
 This tool does not mock out ofono completely, but instead what it creates a
 local server to serve an mms that would be passed on from the Push
@@ -110,15 +110,8 @@ It will track that the correct signals are raised over the bus.
 
 Install it by running:
 
-    go get github.com/ubuntu-phonedations/nuntium/cmd/nuntium-stub-send
+    go get github.com/ubports/nuntium/cmd/nuntium-stub-send
 
 Refer to the tool's
-[documentation](http://godoc.org/github.com/ubuntu-phonedations/nuntium/cmd/nuntium-stub-send)
+[documentation](https://pkg.go.dev/github.com/ubports/nuntium/cmd/nuntium-stub-send)
 for more information.
-
-
-## Installing on Ubuntu
-
-On Ubuntu (vivid+), all of the `nuntium-*` tools can be installed by
-
-    sudo apt install nuntium-tools

--- a/ofono/push.go
+++ b/ofono/push.go
@@ -26,7 +26,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/ubuntu-phonedations/nuntium/mms"
+	"github.com/ubports/nuntium/mms"
 )
 
 type PDU byte

--- a/ofono/push_decode_test.go
+++ b/ofono/push_decode_test.go
@@ -25,7 +25,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/ubuntu-phonedations/nuntium/mms"
+	"github.com/ubports/nuntium/mms"
 	. "launchpad.net/gocheck"
 )
 

--- a/ofono/pushagent.go
+++ b/ofono/pushagent.go
@@ -27,7 +27,7 @@ import (
 	"log"
 	"sync"
 
-	"github.com/ubuntu-phonedations/nuntium/mms"
+	"github.com/ubports/nuntium/mms"
 	"launchpad.net/go-dbus/v1"
 )
 

--- a/telepathy/service.go
+++ b/telepathy/service.go
@@ -30,8 +30,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ubuntu-phonedations/nuntium/mms"
-	"github.com/ubuntu-phonedations/nuntium/storage"
+	"github.com/ubports/nuntium/mms"
+	"github.com/ubports/nuntium/storage"
 	"launchpad.net/go-dbus/v1"
 )
 


### PR DESCRIPTION
Follows PRs #6 & #7 

This PR proposes to cut ties from ubuntu-phonedations repo for good. This step is essential for further development of ```nuntium```. For example without this, any change to [nuntium/ofono package](https://github.com/ubports/nuntium/tree/xenial/ofono) wouldn't have any effect, cause ```nuntium``` [builds against ubutu-ponedations packages](https://github.com/ubports/nuntium/blob/38940464d532a145412c47d8901c1a74fb662eff/cmd/nuntium/main.go#L29-L30). I've splitted this changes into some commits for better clarity, with some insights in commit descriptions.