### PR TITLE
Update debian/changelog with previous changes descriptions

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,17 @@
+nuntium (2.0) xenial; urgency=medium
+
+  * Store incoming message notification (MN)
+  * Send error message to telepathy-ofono on failed MN handling
+  * Listen to and handle re-download requests of failed MN
+  * Handle MNs with the same id to prevent duplicate user notifications
+  * Change MN Expiry field format and handle absolute/relative token during
+  	decoding
+  * Storage cleanup and MN error recovery on application start
+  * Introduce new flags for the nuntium-inject-push command
+  * Update architecture documentation.
+
+ -- jEzEk <jezek@chicki.sk>  Mon, 3 Jan 2022 18:03:08 +0200
+ 
 nuntium (1.4+ubports1) xenial; urgency=medium
 
   * Imported to UBports


### PR DESCRIPTION
Hello,

this PR is cause I forgot to place version change, summary  and credentials to debian/changelog in my previous PR #8 .

I think the version should bump up major rank, because I broke compatibility of some exported methods for some packages. Is it OKj?

Question: I put the ```+ubports1``` string after version, just because it was there before. Does it needs to be there? Does it serve any purpose?

Note: Maybe the merging should wait until OTA-21 is out to not interfere in the QA